### PR TITLE
Add support for fields

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/.direnv
+/.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "documented"
 version = "0.1.2"
 dependencies = [
  "documented-derive",
+ "phf",
 ]
 
 [[package]]
@@ -22,6 +23,48 @@ name = "documented-test"
 version = "0.1.2"
 dependencies = [
  "documented",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -41,6 +84,27 @@ checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
   "documented-derive",
   "documented-test",
 ]
+
+[workspace.dependencies]
+phf = { version = "0.11", default-features = false, features = ["macros"]}

--- a/documented-derive/src/lib.rs
+++ b/documented-derive/src/lib.rs
@@ -1,59 +1,122 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, spanned::Spanned, DeriveInput, Error, Expr, ExprLit, Lit, Meta};
+use syn::{
+    parse_macro_input, parse_quote, spanned::Spanned, Attribute, Data, DataEnum, DataStruct,
+    DataUnion, DeriveInput, Error, Expr, ExprLit, Lit, Meta, Path,
+};
+
+fn crate_module_path() -> Path {
+    parse_quote!(::documented)
+}
 
 /// Derive proc-macro for `Documented` trait.
 #[proc_macro_derive(Documented)]
 pub fn documented(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    let ident = input.ident;
+    let doc_comments = match get_comment(input.attrs.clone()) {
+        Ok(Some(r)) => r,
+        // Should we use an Option instead?
+        Ok(None) => "".to_string(),
+        Err(e) => return e.into_compile_error().into(),
+    };
 
-    let doc_comments = {
-        let maybe_str_literals = input
-            .attrs
-            .into_iter()
-            .filter_map(|attr| match attr.meta {
-                Meta::NameValue(name_value) if name_value.path.is_ident("doc") => {
-                    Some(name_value.value)
-                }
-                _ => None,
-            })
-            .map(|expr| match expr {
-                Expr::Lit(ExprLit { lit: Lit::Str(s), .. }) => Ok(s.value()),
-                e => Err(e),
-            })
-            .collect::<Result<Vec<_>, _>>();
-
-        let literals = match maybe_str_literals {
-            Ok(lits) => lits,
-            Err(expr) => {
-                return Error::new(expr.span(), "Doc comment is not a string literal")
-                    .into_compile_error()
-                    .into()
+    let fields_doc_comments = {
+        let fields_attrs: Vec<(syn::Ident, Vec<Attribute>)> = match input.data.clone() {
+            Data::Enum(DataEnum { variants, .. }) => {
+                variants.into_iter().map(|v| (v.ident, v.attrs)).collect()
             }
+            Data::Struct(DataStruct { fields, .. }) => fields
+                .into_iter()
+                .filter(|f| f.ident.is_some())
+                .map(|f| (f.ident.unwrap(), f.attrs))
+                .collect(),
+            Data::Union(DataUnion { fields, .. }) => fields
+                .named
+                .into_iter()
+                .map(|f| (f.ident.unwrap(), f.attrs))
+                .collect(),
         };
 
-        if literals.len() == 0 {
-            return Error::new(ident.span(), "No doc comment found on this type")
-                .into_compile_error()
-                .into();
+        match fields_attrs
+            .into_iter()
+            .map(|(i, attrs)| get_comment(attrs).map(|c| (i, c.unwrap_or_default())))
+            .collect::<syn::Result<Vec<_>>>()
+        {
+            Ok(t) => t,
+            Err(e) => return e.into_compile_error().into(),
         }
-
-        let trimmed: Vec<_> = literals
-            .iter()
-            .flat_map(|lit| lit.split("\n").collect::<Vec<_>>())
-            .map(|line| line.trim().to_string())
-            .collect();
-
-        trimmed.join("\n")
     };
+
+    let ident = input.ident;
+
+    let (field_idents, field_comments): (Vec<_>, Vec<_>) = fields_doc_comments.into_iter().unzip();
+
+    let phf_match_arms: Vec<_> = field_idents
+        .into_iter()
+        .map(|ident| ident.to_string())
+        .enumerate()
+        .map(|(i, ident)| quote! { #ident => #i, })
+        .collect();
+
+    let documented_module_path = crate_module_path();
 
     quote! {
         #[automatically_derived]
         impl documented::Documented for #ident {
             const DOCS: &'static str = #doc_comments;
+
+            const FIELD_DOCS: &'static [&'static str] = &[#(#field_comments),*];
+
+            fn get_index_by_name<T: AsRef<str>>(field_name: T) -> Option<usize> {
+                use #documented_module_path::_private_phf_reexport_for_macro as phf;
+
+                static PHF: phf::Map<&'static str, usize> = phf::phf_map! {
+                    #(#phf_match_arms)*
+                };
+                PHF.get(field_name.as_ref()).copied()
+            }
         }
     }
     .into()
+}
+
+fn get_comment(attrs: Vec<Attribute>) -> syn::Result<Option<String>> {
+    let maybe_str_literals = attrs
+        .into_iter()
+        .filter_map(|attr| match attr.meta {
+            Meta::NameValue(name_value) if name_value.path.is_ident("doc") => {
+                Some(name_value.value)
+            }
+            _ => None,
+        })
+        .map(|expr| match expr {
+            Expr::Lit(ExprLit {
+                lit: Lit::Str(s), ..
+            }) => Ok(s.value()),
+            e => Err(e),
+        })
+        .collect::<Result<Vec<_>, _>>();
+
+    let literals = match maybe_str_literals {
+        Ok(lits) => lits,
+        Err(expr) => {
+            return Err(Error::new(
+                expr.span(),
+                "Doc comment is not a string literal",
+            ))
+        }
+    };
+
+    if literals.is_empty() {
+        return Ok(None);
+    }
+
+    let trimmed: Vec<_> = literals
+        .iter()
+        .flat_map(|lit| lit.split("\n").collect::<Vec<_>>())
+        .map(|line| line.trim().to_string())
+        .collect();
+
+    Ok(Some(trimmed.join("\n")))
 }

--- a/documented-test/src/lib.rs
+++ b/documented-test/src/lib.rs
@@ -6,9 +6,20 @@ mod test_use {
     fn it_works() {
         /// 69
         #[derive(Documented)]
-        struct Nice;
+        #[allow(dead_code)]
+        struct Nice {
+            /// 1
+            first: i32,
+            second: i32,
+            /// 3
+            third: i32,
+        }
 
         assert_eq!(Nice::DOCS, "69");
+        assert_eq!(Nice::FIELD_DOCS.len(), 3);
+        assert_eq!(Nice::get_field_comment("first"), Some("1"));
+        assert_eq!(Nice::get_field_comment("second"), Some(""));
+        assert_eq!(Nice::get_field_comment("third"), Some("3"));
     }
 
     #[test]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,129 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1694959747,
+        "narHash": "sha256-CXQ2MuledDVlVM5dLC4pB41cFlBWxRw4tCBsFrq3cRk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "970a59bd19eff3752ce552935687100c46e820a5",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1695175880,
+        "narHash": "sha256-TBR5/K3jkrd+U5mjxvRvUhlcT1Hw9jFywz1TjAGZRm4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e054ca37ee416efe9d8fc72d249ec332ef74b6d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "Server app for SlimeVR ecosystem";
+
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+  }:
+    flake-utils.lib.eachDefaultSystem
+    (
+      system: let
+        overlays = [(import rust-overlay)];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        rustTarget =
+          pkgs.rust-bin.stable.latest.default.override
+          {
+            extensions = ["rust-analyzer" "rust-src"];
+          };
+        nativeBuildInputs = with pkgs; [
+          curl
+          gcc
+          pkg-config
+          which
+          zlib
+        ];
+        buildInputs = with pkgs; [
+        ];
+      in {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs =
+            nativeBuildInputs
+            ++ [
+            ];
+          buildInputs =
+            buildInputs
+            ++ [
+              rustTarget
+            ];
+        };
+      }
+    );
+}

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,3 +12,4 @@ version = "0.1.2"
 
 [dependencies]
 documented-derive = {path = "../documented-derive", version = "0.1.2"}
+phf.workspace = true

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,8 +1,21 @@
 pub use documented_derive::Documented;
 
+#[doc(hidden)]
+pub use phf as _private_phf_reexport_for_macro;
+
 /// Adds an associated constant `DOCS` on your type containing its documentation,
 /// allowing you to access its documentation at runtime.
 pub trait Documented {
     /// The static doc comments on this type.
     const DOCS: &'static str;
+
+    /// Each index is a different field docs.
+    /// It's indexed by field order.
+    const FIELD_DOCS: &'static [&'static str];
+
+    fn get_index_by_name<T: AsRef<str>>(field_name: T) -> Option<usize>;
+
+    fn get_field_comment<T: AsRef<str>>(field_name: T) -> Option<&'static str> {
+        Self::get_index_by_name(field_name).map(|i| Self::FIELD_DOCS[i])
+    }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,2 @@
+# Just uses the flake. For the nix-env addon (which is kind of dead) users, I use the direnv addon.
+(builtins.getFlake ("git+file://" + toString ./.)).devShells.${builtins.currentSystem}.default


### PR DESCRIPTION
Closes #1 

* removes behavior of erroring when no comment found and instead just returns an empty string (Discuss if it should be an `Option` or not)
* decoupled comment fetching behavior to just require the `Vec<Attribute>`
* makes an array of comments, being each index a different field
* exposes `phf` in the main crate for the macro to use
* makes a function with an static `phf` map which stores the field's name and the index to the field's comment
* half-do a test