### PR TITLE
Allow customising macro behaviour using derive attributes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,12 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo clippy --workspace -- -D warnings
+        run: |
+          cargo clippy --workspace -- -D warnings
+          cargo clippy --workspace --no-default-features -- -D warnings
+
 
       - name: Run tests
-        run: cargo test --workspace
+        run: |
+          cargo test --workspace
+          cargo test --workspace --no-default-features

--- a/documented-derive/Cargo.toml
+++ b/documented-derive/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 proc-macro = true
 
 [dependencies]
+optfield = "0.3.0"
 quote = "1.0.35"
 syn = "2.0.58"
 

--- a/documented-derive/Cargo.toml
+++ b/documented-derive/Cargo.toml
@@ -11,9 +11,13 @@ version.workspace = true
 proc-macro = true
 
 [dependencies]
-optfield = "0.3.0"
+optfield = { version = "0.3.0", optional = true }
 quote = "1.0.35"
 syn = "2.0.58"
 
 [dev-dependencies]
 documented = { path = "../lib" }
+
+[features]
+customise = ["dep:optfield"]
+default = ["customise"]

--- a/documented-derive/src/config.rs
+++ b/documented-derive/src/config.rs
@@ -1,0 +1,123 @@
+use optfield::optfield;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse2,
+    punctuated::Punctuated,
+    spanned::Spanned,
+    Attribute, Error, LitBool, Meta, Token,
+};
+
+/// Configurable options via helper attributes.
+///
+/// Initial values are set to default.
+#[optfield(
+    pub ConfigCustomisations,
+    attrs = add(derive(Default)),
+    merge_fn = pub apply_customisations,
+    doc = "Parsed user-defined customisations of configurable options.\n\
+    \n\
+    Expected parse stream format: `<KW> = <VAL>, <KW> = <VAL>, ...`"
+)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Config {
+    pub trim: bool,
+}
+impl Default for Config {
+    fn default() -> Self {
+        Self { trim: true }
+    }
+}
+impl Config {
+    /// Return a new instance of this config with customisations applied.
+    pub fn with_customisations(mut self, customisations: ConfigCustomisations) -> Self {
+        self.apply_customisations(customisations);
+        self
+    }
+}
+
+impl Parse for ConfigCustomisations {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let args = Punctuated::<ConfigOption, Token![,]>::parse_terminated(input)?;
+
+        let mut config = Self::default();
+        for arg in args {
+            match arg {
+                ConfigOption::Trim(kw, _) if config.trim.is_some() => Err(Error::new(
+                    kw.span(),
+                    "This config option cannot be specified more than once",
+                ))?,
+                ConfigOption::Trim(_, val) => {
+                    config.trim.replace(val);
+                }
+            }
+        }
+        Ok(config)
+    }
+}
+
+mod kw {
+    use syn::custom_keyword;
+
+    custom_keyword!(trim);
+}
+
+/// All known configuration options.
+///
+/// Expected parse stream format: `<KW> = <VAL>`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum ConfigOption {
+    /// Trim each line or not.
+    ///
+    /// E.g. `trim = false`.
+    Trim(kw::trim, bool),
+}
+impl Parse for ConfigOption {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(kw::trim) {
+            let kw = input.parse::<kw::trim>()?;
+            input.parse::<Token![=]>()?;
+            let trim = input.parse::<LitBool>()?;
+            Ok(Self::Trim(kw, trim.value))
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+pub fn get_config_customisations(
+    attrs: &[Attribute],
+    attr_name: &str,
+) -> syn::Result<Option<ConfigCustomisations>> {
+    let customise_attrs = attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident(attr_name))
+        .map(|attr| match &attr.meta {
+            Meta::List(attr_inner) => Ok(attr_inner),
+            other_form => Err(Error::new(
+                other_form.span(),
+                format!("{attr_name} is not list-like. Expecting `{attr_name}(...)`"),
+            )),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let customise_attr = match customise_attrs.len() {
+        0 => return Ok(None),
+        1 => customise_attrs[0].clone(),
+        _ => {
+            let mut it = customise_attrs.iter();
+            let initial_error = Error::new(
+                it.next().unwrap().span(),
+                format!("{attr_name} can only be declared once"),
+            );
+            let final_error = it.fold(initial_error, |mut err, declaration| {
+                err.combine(Error::new(declaration.span(), "Duplicate declaration here"));
+                err
+            });
+            Err(final_error)?
+        }
+    };
+
+    let customisations = parse2::<ConfigCustomisations>(customise_attr.tokens)?;
+    Ok(Some(customisations))
+}

--- a/documented-derive/src/config.rs
+++ b/documented-derive/src/config.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "customise")]
 use optfield::optfield;
+#[cfg(feature = "customise")]
 use syn::{
     parse::{Parse, ParseStream},
     parse2,
@@ -10,14 +12,14 @@ use syn::{
 /// Configurable options via helper attributes.
 ///
 /// Initial values are set to default.
-#[optfield(
+#[cfg_attr(feature = "customise", optfield(
     pub ConfigCustomisations,
     attrs = add(derive(Default)),
     merge_fn = pub apply_customisations,
     doc = "Parsed user-defined customisations of configurable options.\n\
     \n\
     Expected parse stream format: `<KW> = <VAL>, <KW> = <VAL>, ...`"
-)]
+))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Config {
     pub trim: bool,
@@ -35,6 +37,7 @@ impl Config {
     }
 }
 
+#[cfg(feature = "customise")]
 impl Parse for ConfigCustomisations {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let args = Punctuated::<ConfigOption, Token![,]>::parse_terminated(input)?;
@@ -55,6 +58,7 @@ impl Parse for ConfigCustomisations {
     }
 }
 
+#[cfg(feature = "customise")]
 mod kw {
     use syn::custom_keyword;
 
@@ -64,6 +68,7 @@ mod kw {
 /// All known configuration options.
 ///
 /// Expected parse stream format: `<KW> = <VAL>`.
+#[cfg(feature = "customise")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum ConfigOption {
     /// Trim each line or not.
@@ -71,6 +76,7 @@ enum ConfigOption {
     /// E.g. `trim = false`.
     Trim(kw::trim, bool),
 }
+#[cfg(feature = "customise")]
 impl Parse for ConfigOption {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let lookahead = input.lookahead1();
@@ -85,6 +91,7 @@ impl Parse for ConfigOption {
     }
 }
 
+#[cfg(feature = "customise")]
 pub fn get_config_customisations(
     attrs: &[Attribute],
     attr_name: &str,

--- a/documented-derive/src/lib.rs
+++ b/documented-derive/src/lib.rs
@@ -43,6 +43,26 @@ fn crate_module_path() -> Path {
 /// Attribute-style documentation is supported too.";
 /// assert_eq!(BornIn69::DOCS, doc_str);
 /// ```
+///
+/// # Configuration
+///
+/// With the `customise` feature enabled, you can customise this macro's
+/// behaviour using the `#[documented(...)]` attribute.
+///
+/// Currently, you can disable line-trimming like so:
+///
+/// ```rust
+/// # use documented::Documented;
+/// ///     Terrible.
+/// #[derive(Documented)]
+/// #[documented(trim = false)]
+/// struct Frankly;
+///
+/// assert_eq!(Frankly::DOCS, "     Terrible.");
+/// ```
+///
+/// If there are other configuration options you wish to have, please submit an
+/// issue or a PR.
 #[cfg_attr(not(feature = "customise"), proc_macro_derive(Documented))]
 #[cfg_attr(
     feature = "customise",
@@ -91,12 +111,12 @@ pub fn documented(input: TokenStream) -> TokenStream {
 ///
 /// #[derive(DocumentedFields)]
 /// struct BornIn69 {
-///     /// Frankly, delicious.
+///     /// Cry like a grandmaster.
 ///     rawr: String,
 ///     explosive: usize,
 /// };
 ///
-/// assert_eq!(BornIn69::FIELD_DOCS, [Some("Frankly, delicious."), None]);
+/// assert_eq!(BornIn69::FIELD_DOCS, [Some("Cry like a grandmaster."), None]);
 /// ```
 ///
 /// You can also use [`get_field_docs`](Self::get_field_docs) to access the
@@ -107,12 +127,12 @@ pub fn documented(input: TokenStream) -> TokenStream {
 /// #
 /// # #[derive(DocumentedFields)]
 /// # struct BornIn69 {
-/// #     /// Frankly, delicious.
+/// #     /// Cry like a grandmaster.
 /// #     rawr: String,
 /// #     explosive: usize,
 /// # };
 /// #
-/// assert_eq!(BornIn69::get_field_docs("rawr"), Ok("Frankly, delicious."));
+/// assert_eq!(BornIn69::get_field_docs("rawr"), Ok("Cry like a grandmaster."));
 /// assert_eq!(
 ///     BornIn69::get_field_docs("explosive"),
 ///     Err(Error::NoDocComments("explosive".to_string()))
@@ -122,6 +142,34 @@ pub fn documented(input: TokenStream) -> TokenStream {
 ///     Err(Error::NoSuchField("gotcha".to_string()))
 /// );
 /// ```
+///
+/// # Configuration
+///
+/// With the `customise` feature enabled, you can customise this macro's
+/// behaviour using the `#[documented_fields(...)]` attribute. Note that this
+/// attribute works on both the container and each individual field, with the
+/// per-field configurations overriding container configurations, which
+/// override the default.
+///
+/// Currently, you can (selectively) disable line-trimming like so:
+///
+/// ```rust
+/// # use documented::DocumentedFields;
+/// #[derive(DocumentedFields)]
+/// #[documented_fields(trim = false)]
+/// struct Frankly {
+///     ///     Delicious.
+///     perrier: usize,
+///     ///     I'm vegan.
+///     #[documented_fields(trim = true)]
+///     fried_liver: bool,
+/// }
+///
+/// assert_eq!(Frankly::FIELD_DOCS, [Some("     Delicious."), Some("I'm vegan.")]);
+/// ```
+///
+/// If there are other configuration options you wish to have, please
+/// submit an issue or a PR.
 #[cfg_attr(not(feature = "customise"), proc_macro_derive(DocumentedFields))]
 #[cfg_attr(
     feature = "customise",
@@ -240,6 +288,37 @@ pub fn documented_fields(input: TokenStream) -> TokenStream {
 ///     Ok("I fell out of my chair.")
 /// );
 /// ```
+///
+/// # Configuration
+///
+/// With the `customise` feature enabled, you can customise this macro's
+/// behaviour using the `#[documented_variants(...)]` attribute. Note that this
+/// attribute works on both the container and each individual variant, with the
+/// per-variant configurations overriding container configurations, which
+/// override the default.
+///
+/// Currently, you can (selectively) disable line-trimming like so:
+///
+/// ```rust
+/// # use documented::DocumentedVariants;
+/// #[derive(DocumentedVariants)]
+/// #[documented_variants(trim = false)]
+/// enum Always {
+///     ///     Or the quality.
+///     SacTheExchange,
+///     ///     Like a Frenchman.
+///     #[documented_variants(trim = true)]
+///     Retreat,
+/// }
+/// assert_eq!(
+///     Always::SacTheExchange.get_variant_docs(),
+///     Ok("     Or the quality.")
+/// );
+/// assert_eq!(Always::Retreat.get_variant_docs(), Ok("Like a Frenchman."));
+/// ```
+///
+/// If there are other configuration options you wish to have, please
+/// submit an issue or a PR.
 #[cfg_attr(not(feature = "customise"), proc_macro_derive(DocumentedVariants))]
 #[cfg_attr(
     feature = "customise",

--- a/documented-derive/src/lib.rs
+++ b/documented-derive/src/lib.rs
@@ -1,9 +1,13 @@
+mod config;
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
     parse_macro_input, parse_quote, spanned::Spanned, Attribute, Data, DataEnum, DataStruct,
     DataUnion, DeriveInput, Error, Expr, ExprLit, Fields, Ident, Lit, Meta, Path,
 };
+
+use crate::config::{get_config_customisations, Config};
 
 fn crate_module_path() -> Path {
     parse_quote!(::documented)
@@ -37,14 +41,20 @@ fn crate_module_path() -> Path {
 /// Attribute-style documentation is supported too.";
 /// assert_eq!(BornIn69::DOCS, doc_str);
 /// ```
-#[proc_macro_derive(Documented)]
+#[proc_macro_derive(Documented, attributes(documented))]
 pub fn documented(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     let ident = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    let docs = match get_docs(&input.attrs) {
+    let config = match get_config_customisations(&input.attrs, "documented") {
+        Ok(Some(customisations)) => Config::default().with_customisations(customisations),
+        Ok(None) => Config::default(),
+        Err(err) => return err.into_compile_error().into(),
+    };
+
+    let docs = match get_docs(&input.attrs, &config) {
         Ok(Some(doc)) => doc,
         Ok(None) => {
             return Error::new(input.ident.span(), "Missing doc comments")
@@ -103,12 +113,19 @@ pub fn documented(input: TokenStream) -> TokenStream {
 ///     Err(Error::NoSuchField("gotcha".to_string()))
 /// );
 /// ```
-#[proc_macro_derive(DocumentedFields)]
+#[proc_macro_derive(DocumentedFields, attributes(documented_fields))]
 pub fn documented_fields(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     let ident = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    // `#[documented_fields(...)]` on container type
+    let base_config = match get_config_customisations(&input.attrs, "documented_fields") {
+        Ok(Some(customisations)) => Config::default().with_customisations(customisations),
+        Ok(None) => Config::default(),
+        Err(err) => return err.into_compile_error().into(),
+    };
 
     let (field_idents, field_docs): (Vec<_>, Vec<_>) = {
         let fields_attrs: Vec<(Option<Ident>, Vec<Attribute>)> = match input.data.clone() {
@@ -128,7 +145,15 @@ pub fn documented_fields(input: TokenStream) -> TokenStream {
 
         match fields_attrs
             .into_iter()
-            .map(|(i, attrs)| get_docs(&attrs).map(|d| (i, d)))
+            .map(|(i, attrs)| {
+                let config =
+                    if let Some(c) = get_config_customisations(&attrs, "documented_fields")? {
+                        base_config.with_customisations(c)
+                    } else {
+                        base_config
+                    };
+                get_docs(&attrs, &config).map(|d| (i, d))
+            })
             .collect::<syn::Result<Vec<_>>>()
         {
             Ok(t) => t.into_iter().unzip(),
@@ -196,12 +221,19 @@ pub fn documented_fields(input: TokenStream) -> TokenStream {
 ///     Ok("I fell out of my chair.")
 /// );
 /// ```
-#[proc_macro_derive(DocumentedVariants)]
+#[proc_macro_derive(DocumentedVariants, attributes(documented_variants))]
 pub fn documented_variants(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     let ident = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    // `#[documented_variants(...)]` on container type
+    let base_config = match get_config_customisations(&input.attrs, "documented_variants") {
+        Ok(Some(customisations)) => Config::default().with_customisations(customisations),
+        Ok(None) => Config::default(),
+        Err(err) => return err.into_compile_error().into(),
+    };
 
     let variants_docs = {
         let Data::Enum(DataEnum { variants, .. }) = input.data else {
@@ -216,7 +248,15 @@ pub fn documented_variants(input: TokenStream) -> TokenStream {
         match variants
             .into_iter()
             .map(|v| (v.ident, v.fields, v.attrs))
-            .map(|(i, f, attrs)| get_docs(&attrs).map(|d| (i, f, d)))
+            .map(|(i, f, attrs)| {
+                let config =
+                    if let Some(c) = get_config_customisations(&attrs, "documented_variants")? {
+                        base_config.with_customisations(c)
+                    } else {
+                        base_config
+                    };
+                get_docs(&attrs, &config).map(|d| (i, f, d))
+            })
             .collect::<syn::Result<Vec<_>>>()
         {
             Ok(t) => t,
@@ -259,7 +299,7 @@ pub fn documented_variants(input: TokenStream) -> TokenStream {
     .into()
 }
 
-fn get_docs(attrs: &[Attribute]) -> syn::Result<Option<String>> {
+fn get_docs(attrs: &[Attribute], config: &Config) -> syn::Result<Option<String>> {
     let string_literals = attrs
         .iter()
         .filter_map(|attr| match attr.meta {
@@ -281,11 +321,16 @@ fn get_docs(attrs: &[Attribute]) -> syn::Result<Option<String>> {
         return Ok(None);
     }
 
-    let trimmed: Vec<_> = string_literals
-        .iter()
-        .flat_map(|lit| lit.split('\n').collect::<Vec<_>>())
-        .map(|line| line.trim().to_string())
-        .collect();
+    let docs = if config.trim {
+        string_literals
+            .iter()
+            .flat_map(|lit| lit.split('\n').collect::<Vec<_>>())
+            .map(|line| line.trim().to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        string_literals.join("\n")
+    };
 
-    Ok(Some(trimmed.join("\n")))
+    Ok(Some(docs))
 }

--- a/documented-test/Cargo.toml
+++ b/documented-test/Cargo.toml
@@ -7,3 +7,7 @@ version.workspace = true
 
 [dev-dependencies]
 documented = { path = "../lib" }
+
+[features]
+customise = ["documented/customise"]
+default = ["customise"]

--- a/documented-test/src/documented.rs
+++ b/documented-test/src/documented.rs
@@ -119,3 +119,42 @@ mod test_qualified {
         assert_eq!(<Nice as documented::Documented>::DOCS, "69");
     }
 }
+
+#[cfg(feature = "customise")]
+mod test_customise {
+    use documented::Documented;
+
+    #[test]
+    fn empty_customise_works() {
+        /** Wow
+            much
+            doge
+        */
+        #[derive(Documented)]
+        #[documented()]
+        struct Doge;
+
+        let doc_str = "Wow
+much
+doge
+";
+        assert_eq!(Doge::DOCS, doc_str);
+    }
+
+    #[test]
+    fn trim_false_works() {
+        /** Wow
+            much
+            doge
+        */
+        #[derive(Documented)]
+        #[documented(trim = false)]
+        struct Doge;
+
+        let doc_str = " Wow
+            much
+            doge
+        ";
+        assert_eq!(Doge::DOCS, doc_str);
+    }
+}

--- a/documented-test/src/documented_fields.rs
+++ b/documented-test/src/documented_fields.rs
@@ -135,3 +135,70 @@ fn lifetimed_type_works() {
 
     assert_eq!(Foo::get_field_docs("foo"), Ok("foo"));
 }
+
+#[cfg(feature = "customise")]
+mod test_customise {
+    use documented::DocumentedFields;
+
+    #[test]
+    fn empty_customise_works() {
+        #[derive(DocumentedFields)]
+        #[documented_fields()]
+        #[allow(dead_code)]
+        struct Doge {
+            /// Wow, much coin
+            coin: usize,
+        }
+
+        assert_eq!(Doge::get_field_docs("coin"), Ok("Wow, much coin"));
+    }
+
+    #[test]
+    fn container_customise_works() {
+        #[derive(DocumentedFields)]
+        #[documented_fields(trim = false)]
+        #[allow(dead_code)]
+        struct Doge {
+            ///     Wow, much coin
+            coin: usize,
+            ///     Wow, much doge
+            doge: bool,
+        }
+
+        assert_eq!(Doge::get_field_docs("coin"), Ok("     Wow, much coin"));
+        assert_eq!(Doge::get_field_docs("doge"), Ok("     Wow, much doge"));
+    }
+
+    #[test]
+    fn field_customise_works() {
+        #[derive(DocumentedFields)]
+        #[allow(dead_code)]
+        struct Doge {
+            ///     Wow, much coin
+            #[documented_fields(trim = false)]
+            coin: usize,
+            ///     Wow, much doge
+            doge: bool,
+        }
+
+        assert_eq!(Doge::get_field_docs("coin"), Ok("     Wow, much coin"));
+        assert_eq!(Doge::get_field_docs("doge"), Ok("Wow, much doge"));
+    }
+
+    #[test]
+    fn field_customise_override_works() {
+        #[derive(DocumentedFields)]
+        #[documented_fields(trim = false)]
+        #[allow(dead_code)]
+        struct Doge {
+            ///     Wow, much coin
+            #[documented_fields(trim = true)]
+            coin: usize,
+            ///     Wow, much doge
+            doge: bool,
+        }
+
+        assert_eq!(Doge::get_field_docs("coin"), Ok("Wow, much coin"));
+        assert_eq!(Doge::get_field_docs("doge"), Ok("     Wow, much doge"));
+    }
+}

--- a/documented-test/src/documented_variants.rs
+++ b/documented-test/src/documented_variants.rs
@@ -111,3 +111,73 @@ fn works_on_lifetimed_enums() {
     assert_eq!(Foo::Rufus(&69).get_variant_docs(), Ok("600"));
     assert_eq!(Foo::Dufus(69, &420).get_variant_docs(), Ok("599"));
 }
+
+#[cfg(feature = "customise")]
+mod test_customise {
+    use documented::DocumentedVariants;
+
+    #[test]
+    fn empty_customise_works() {
+        #[derive(DocumentedVariants)]
+        #[documented_variants()]
+        #[allow(dead_code)]
+        enum Name {
+            /// Wow
+            Doge,
+            /// RIP
+            Kabuso,
+        }
+
+        assert_eq!(Name::Doge.get_variant_docs(), Ok("Wow"));
+        assert_eq!(Name::Kabuso.get_variant_docs(), Ok("RIP"));
+    }
+
+    #[test]
+    fn container_customise_works() {
+        #[derive(DocumentedVariants)]
+        #[documented_variants(trim = false)]
+        #[allow(dead_code)]
+        enum Name {
+            ///     Wow
+            Doge,
+            ///     RIP
+            Kabuso,
+        }
+
+        assert_eq!(Name::Doge.get_variant_docs(), Ok("     Wow"));
+        assert_eq!(Name::Kabuso.get_variant_docs(), Ok("     RIP"));
+    }
+
+    #[test]
+    fn field_customise_works() {
+        #[derive(DocumentedVariants)]
+        #[allow(dead_code)]
+        enum Name {
+            ///     Wow
+            #[documented_variants(trim = false)]
+            Doge,
+            ///     RIP
+            Kabuso,
+        }
+
+        assert_eq!(Name::Doge.get_variant_docs(), Ok("     Wow"));
+        assert_eq!(Name::Kabuso.get_variant_docs(), Ok("RIP"));
+    }
+
+    #[test]
+    fn field_customise_override_works() {
+        #[derive(DocumentedVariants)]
+        #[documented_variants(trim = false)]
+        #[allow(dead_code)]
+        enum Name {
+            ///     Wow
+            #[documented_variants(trim = true)]
+            Doge,
+            ///     RIP
+            Kabuso,
+        }
+
+        assert_eq!(Name::Doge.get_variant_docs(), Ok("Wow"));
+        assert_eq!(Name::Kabuso.get_variant_docs(), Ok("     RIP"));
+    }
+}

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,3 +15,7 @@ version.workspace = true
 documented-derive = { path = "../documented-derive", version = "0.4.3" }
 phf = { version = "0.11", default-features = false, features = ["macros"] }
 thiserror = "1.0.58"
+
+[features]
+customise = ["documented-derive/customise"]
+default = ["customise"]


### PR DESCRIPTION
- `Documented`: `#[documented(...)]`
- `DocumentedFields`: `#[documented_fields(...)]`
- `DocumentedVariants`: `#[documented_variants(...)]`

Available under the `customise` feature (enabled by default).