### PR TITLE
Added an accessible array of field names to DocumentedFields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "cyqsimon <28627918+cyqsimon@users.noreply.github.com>",
     "Uriel <urielfontan2002@gmail.com>",
     "Sese Mueller <sese4dasbinichagmail.com>",
+    "Lauréline <git@compilin.dev>",
 ]
 categories = ["rust-patterns"]
 edition = "2021"

--- a/documented-macros/src/derive_impl.rs
+++ b/documented-macros/src/derive_impl.rs
@@ -160,12 +160,12 @@ pub fn documented_fields_impl(input: DeriveInput, docs_ty: DocType) -> syn::Resu
         .into_iter()
         .unzip::<_, _, Vec<_>, Vec<_>>();
 
-    let (field_names, phf_match_arms): (Vec<_>, Vec<_>) = field_names
+    let (field_names, phf_match_arms) = field_names
         .into_iter()
         .enumerate()
-        .filter_map(|(i, field)| field.map(|field| (i, field.as_str().to_token_stream())))
+        .filter_map(|(i, field)| field.map(|field| (i, field.as_str().to_owned())))
         .map(|(i, name)| (name.clone(), quote! { #name => #i, }))
-        .unzip();
+        .unzip::<_, _, Vec<_>, Vec<_>>();
 
     let documented_module_path = crate_module_path();
 

--- a/documented-test/src/derive/documented_fields.rs
+++ b/documented-test/src/derive/documented_fields.rs
@@ -247,8 +247,10 @@ mod test_customise {
             some_pawns: bool,
         }
 
-        assert_eq!(AlwaysWinning::FIELD_NAMES, &[
-            "OPPOSITE-COLOUR-BISHOPS", "some-ROOKS", "some-pawns"]);
+        assert_eq!(
+            AlwaysWinning::FIELD_NAMES,
+            &["OPPOSITE-COLOUR-BISHOPS", "some-ROOKS", "some-pawns"]
+        );
         assert_eq!(
             AlwaysWinning::get_field_docs("OPPOSITE-COLOUR-BISHOPS"),
             Ok("Gotta be opposite.")

--- a/documented-test/src/derive/documented_fields.rs
+++ b/documented-test/src/derive/documented_fields.rs
@@ -120,6 +120,7 @@ fn lifetimed_type_works() {
         foo: &'a u8,
     }
 
+    assert_eq!(Foo::FIELD_NAMES, &["foo"]);
     assert_eq!(Foo::get_field_docs("foo"), Ok("foo"));
 }
 
@@ -137,6 +138,7 @@ mod test_customise {
             coin: usize,
         }
 
+        assert_eq!(Doge::FIELD_NAMES, &["coin"]);
         assert_eq!(Doge::get_field_docs("coin"), Ok("Wow, much coin"));
     }
 
@@ -153,6 +155,7 @@ mod test_customise {
             coin: usize,
         }
 
+        assert_eq!(Doge::FIELD_NAMES, &["coin"]);
         assert_eq!(Doge::get_field_docs("coin"), Ok("Wow, much coin"));
     }
 
@@ -168,6 +171,7 @@ mod test_customise {
             doge: bool,
         }
 
+        assert_eq!(Doge::FIELD_NAMES, &["coin", "doge"]);
         assert_eq!(Doge::get_field_docs("coin"), Ok("     Wow, much coin"));
         assert_eq!(Doge::get_field_docs("doge"), Ok("     Wow, much doge"));
     }
@@ -184,6 +188,7 @@ mod test_customise {
             doge: bool,
         }
 
+        assert_eq!(Doge::FIELD_NAMES, &["coin", "doge"]);
         assert_eq!(Doge::get_field_docs("coin"), Ok("     Wow, much coin"));
         assert_eq!(Doge::get_field_docs("doge"), Ok("Wow, much doge"));
     }
@@ -201,6 +206,7 @@ mod test_customise {
             doge: bool,
         }
 
+        assert_eq!(Doge::FIELD_NAMES, &["coin", "doge"]);
         assert_eq!(Doge::get_field_docs("coin"), Ok("Wow, much coin"));
         assert_eq!(Doge::get_field_docs("doge"), Ok("     Wow, much doge"));
     }
@@ -219,6 +225,7 @@ mod test_customise {
             Touchdown,
         }
 
+        assert_eq!(Mission::FIELD_NAMES, &["Launch", "Boost", "Touchdown"]);
         assert_eq!(Mission::get_field_docs("Launch"), Ok("Rumble"));
         assert_eq!(Mission::get_field_docs("Boost"), Ok("Woosh"));
         assert_eq!(Mission::get_field_docs("Touchdown"), Ok("Boom"));
@@ -240,6 +247,8 @@ mod test_customise {
             some_pawns: bool,
         }
 
+        assert_eq!(AlwaysWinning::FIELD_NAMES, &[
+            "OPPOSITE-COLOUR-BISHOPS", "some-ROOKS", "some-pawns"]);
         assert_eq!(
             AlwaysWinning::get_field_docs("OPPOSITE-COLOUR-BISHOPS"),
             Ok("Gotta be opposite.")
@@ -266,6 +275,7 @@ mod test_customise {
             usize,
         );
 
+        assert_eq!(OkYouWin::FIELD_NAMES, &["ahhh"]);
         assert_eq!(OkYouWin::FIELD_DOCS.len(), 2);
         assert_eq!(OkYouWin::FIELD_DOCS, ["Leave me alone.", "Just kidding."]);
         assert_eq!(OkYouWin::get_field_docs("ahhh"), Ok("Leave me alone."));

--- a/documented-test/src/derive/documented_fields_opt.rs
+++ b/documented-test/src/derive/documented_fields_opt.rs
@@ -12,6 +12,7 @@ fn it_works() {
         third: i32,
     }
 
+    assert_eq!(Foo::FIELD_NAMES, vec!["first", "second", "third"]);
     assert_eq!(Foo::FIELD_DOCS.len(), 3);
     assert_eq!(Foo::get_field_docs("first"), Ok("1"));
     assert_eq!(
@@ -35,6 +36,7 @@ fn enum_works() {
         Second,
     }
 
+    assert_eq!(Bar::FIELD_NAMES, vec!["First", "Second"]);
     assert_eq!(Bar::FIELD_DOCS.len(), 2);
     assert_eq!(
         Bar::get_field_docs("First"),
@@ -58,6 +60,7 @@ fn union_works() {
         third: i32,
     }
 
+    assert_eq!(FooBar::FIELD_NAMES, vec!["first", "second", "third"]);
     assert_eq!(FooBar::FIELD_DOCS.len(), 3);
     assert_eq!(
         FooBar::get_field_docs("first"),
@@ -89,6 +92,7 @@ mod test_customise {
             Touchdown,
         }
 
+        assert_eq!(Mission::FIELD_NAMES, vec!["Launch", "Boost", "FreeFall", "Touchdown"]);
         assert_eq!(Mission::get_field_docs("Launch"), Ok("Rumble"));
         assert_eq!(Mission::get_field_docs("Boost"), Ok("Woosh"));
         assert_eq!(

--- a/documented-test/src/derive/documented_fields_opt.rs
+++ b/documented-test/src/derive/documented_fields_opt.rs
@@ -92,7 +92,10 @@ mod test_customise {
             Touchdown,
         }
 
-        assert_eq!(Mission::FIELD_NAMES, vec!["Launch", "Boost", "FreeFall", "Touchdown"]);
+        assert_eq!(
+            Mission::FIELD_NAMES,
+            vec!["Launch", "Boost", "FreeFall", "Touchdown"]
+        );
         assert_eq!(Mission::get_field_docs("Launch"), Ok("Rumble"));
         assert_eq!(Mission::get_field_docs("Boost"), Ok("Woosh"));
         assert_eq!(

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -42,6 +42,10 @@ pub trait DocumentedFields {
     /// The static doc comments on each field or variant of this type, indexed
     /// by field/variant order.
     const FIELD_DOCS: &'static [&'static str];
+    /// Field names, as accepted by the function [`Self::get_field_docs`]. Unnamed fields are omitted
+    /// so FIELD_NAMES indices may not match FIELD_DOCS indices. Use [Self::get_field_docs] to
+    /// get the associated docs
+    const FIELD_NAMES: &'static [&'static str];
 
     /// Method internally used by `documented`.
     #[doc(hidden)]
@@ -68,6 +72,8 @@ pub trait DocumentedFieldsOpt {
     /// The static doc comments on each field or variant of this type, indexed
     /// by field/variant order.
     const FIELD_DOCS: &'static [Option<&'static str>];
+    /// Field names, as accepted by the function [`Self::get_field_docs`]
+    const FIELD_NAMES: &'static [&'static str];
 
     /// Method internally used by `documented`.
     #[doc(hidden)]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -42,9 +42,15 @@ pub trait DocumentedFields {
     /// The static doc comments on each field or variant of this type, indexed
     /// by field/variant order.
     const FIELD_DOCS: &'static [&'static str];
-    /// Field names, as accepted by the function [`Self::get_field_docs`]. Unnamed fields are omitted
-    /// so FIELD_NAMES indices may not match FIELD_DOCS indices. Use [Self::get_field_docs] to
-    /// get the associated docs
+    /// Field names, as accepted by [`Self::get_field_docs`].
+    ///
+    /// Note that anonymous fields (i.e. fields in tuple structs), unless they
+    /// have [a custom name set](macro@DocumentedFields#2-set-a-custom-name-for-a-specific-field-for-get_field_docs-like-so),
+    /// will be omitted from `FIELD_NAMES`. This means that in such cases, the
+    /// indices of `FIELD_NAMES` will be misaligned with that of `FIELD_DOCS`.
+    ///
+    /// It is therefore recommended to use [`Self::get_field_docs`] rather than
+    /// the index to lookup the corresponding documentation.
     const FIELD_NAMES: &'static [&'static str];
 
     /// Method internally used by `documented`.
@@ -72,7 +78,15 @@ pub trait DocumentedFieldsOpt {
     /// The static doc comments on each field or variant of this type, indexed
     /// by field/variant order.
     const FIELD_DOCS: &'static [Option<&'static str>];
-    /// Field names, as accepted by the function [`Self::get_field_docs`]
+    /// Field names, as accepted by [`Self::get_field_docs`].
+    ///
+    /// Note that anonymous fields (i.e. fields in tuple structs), unless they
+    /// have [a custom name set](macro@DocumentedFields#2-set-a-custom-name-for-a-specific-field-for-get_field_docs-like-so),
+    /// will be omitted from `FIELD_NAMES`. This means that in such cases, the
+    /// indices of `FIELD_NAMES` will be misaligned with that of `FIELD_DOCS`.
+    ///
+    /// It is therefore recommended to use [`Self::get_field_docs`] rather than
+    /// the index to lookup the corresponding documentation.
     const FIELD_NAMES: &'static [&'static str];
 
     /// Method internally used by `documented`.


### PR DESCRIPTION
Hello, I found your crate while looking for a way to make a struct to deserialize a config file, that I could automatically generate a documentation for said file from by using its fields' docs. Your crate was very close to allowing that but still required to hardcode the field names in order to access their documentation. I thought that since it used those field names already, it would be trivial to store them alongside the docs and make them accessible. And indeed it was.

I don't know if anyone else needs this feature. I would have thought so but I'm surprised by the lack of result while searching for it. Regardless, as far as I can tell this PR doesn't induce any backwards-incompatible changes, so might as well share my patch.

I chose to account for unnamed fields by just omitting them from the array, simplifying access but breaking the field name <=> doc index match (i.e you can't just zip() them), on account of the fact that you can always use get_field_docs to map name to docs. If you prefer an alternate implementation (array of `Optional`s, empty names or other sentinel value for unnamed fields, etc…) I don't mind adjusting it.

I can also try and put this behind a feature flag if you prefer.