### PR TITLE
Fix MSRV-related issues

### DIFF
--- a/.github/scripts/generate-lockfile.sh
+++ b/.github/scripts/generate-lockfile.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This script generates the lockfile for the current toolchain.
+# It is only necessary because the MSRV is currently lower than 1.84.0,
+# which is the minimum needed for resolver v3.
+# If and when the MSRV is raised to or above 1.84.0, this script can be
+# replaced by a simple `cargo generate-lockfile`.
+
+set -e
+
+RESOLVER_V3_MIN_VERSION='1.84.0'
+VERSION="$(cargo --version | cut -d' ' -f2)"
+
+LOWER_VERSION="$(echo -e "$RESOLVER_V3_MIN_VERSION\n$VERSION" | sort --version-sort | head -n1)"
+
+if [[ "$LOWER_VERSION" == "$RESOLVER_V3_MIN_VERSION" ]]; then
+    cargo generate-lockfile
+else
+    # must declare workspace resolver, or it defaults to v1
+    sed -Ei '/resolver ?=/ s/3/2/' Cargo.toml
+
+    cargo generate-lockfile
+
+    # manually downgrade dependencies to compatible versions
+    cargo update --package unicode-segmentation --precise 1.12.0
+fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,12 +51,15 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      - name: Generate lockfile
+        run: .github/scripts/generate-lockfile.sh
+
       - name: Run clippy
         run: |
-          cargo clippy --workspace -- -D warnings
-          cargo clippy --workspace --no-default-features -- -D warnings
+          cargo clippy --locked -- -D warnings
+          cargo clippy --locked --no-default-features -- -D warnings
 
       - name: Run tests
         run: |
-          cargo test --workspace
-          cargo test --workspace --no-default-features
+          cargo test --locked
+          cargo test --locked --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ documented = { path = "lib", default-features = false }
 documented-macros = { path = "documented-macros", version = "0.9.2" }
 itertools = "0.15.0"
 optfield = "0.4.0"
-phf = { version = "0.14", default-features = false, features = ["macros"] }
+phf = { version = "0.13", default-features = false, features = ["macros"] }
 proc-macro2 = "1.0.95"
 quote = "1.0.40"
 strum = { version = "0.28.0", features = ["derive"] }


### PR DESCRIPTION
- Revert `phf` back to 0.13: 0.14 requires 1.85.0.
- Add script to generate Cargo.lock that works for MSRV.